### PR TITLE
(feat): Add location tag for appointments

### DIFF
--- a/configuration/backend_configuration/locationtags/locationtags.csv
+++ b/configuration/backend_configuration/locationtags/locationtags.csv
@@ -5,4 +5,4 @@ a2327745-2970-4752-ac8a-dd0ba131f40e,,Facility Location,
 f5b9737b-14d5-402b-8475-dd558808e172,,Admission Location,Patients may only be admitted to inpatient care in a location with this tag
 9783aba6-df7b-4969-be6e-1e03e7a08965,,Transfer Location,Patients may only be transfer to inpatient care in a location with this tag
 e2a1b3c4-d5e6-7890-1abc-def234567890,,Visit Location,A location where a patient may have a visit
-b5d01d4f-e188-4c6e-a220-c2263b849ad2,,Appointment Location,"When a user user creates a appointment service and chooses a location, they may only choose one with this tag"
+b5d01d4f-e188-4c6e-a220-c2263b849ad2,,Appointment Location,Appointments may only be created and scheduled at locations with this tag

--- a/configuration/backend_configuration/locationtags/locationtags.csv
+++ b/configuration/backend_configuration/locationtags/locationtags.csv
@@ -5,3 +5,4 @@ a2327745-2970-4752-ac8a-dd0ba131f40e,,Facility Location,
 f5b9737b-14d5-402b-8475-dd558808e172,,Admission Location,Patients may only be admitted to inpatient care in a location with this tag
 9783aba6-df7b-4969-be6e-1e03e7a08965,,Transfer Location,Patients may only be transfer to inpatient care in a location with this tag
 e2a1b3c4-d5e6-7890-1abc-def234567890,,Visit Location,A location where a patient may have a visit
+b5d01d4f-e188-4c6e-a220-c2263b849ad2,,Appointment Location,"When a user user creates a appointment service and chooses a location, they may only choose one with this tag"


### PR DESCRIPTION
This PR adds a location tag for appointments. When creating an appointment for a patient, the locations that the user can select are only locations that have the tag `Appointment Location`. Right now this list is empty, because we don't have any locations with this tag. To update our demo locations to have at least one location with this tag, it needs to exist and up until now, we've been apparently manually creating this tag (also, doing this everytime dev3 resets? who is this dedicated?). Anyway, this PR does the location tag `Appointment Location` so we can have a demo appointment location. I think it should go here, and not the demo content package, because it is technically, something that the appointment module requires to function.