### PR TITLE
feat(O3-5372): add billing configuration to core reference application

### DIFF
--- a/configuration/backend_configuration/billableservices/billableServices.csv
+++ b/configuration/backend_configuration/billableservices/billableServices.csv
@@ -1,0 +1,4 @@
+Uuid, Void/Retire, Service Name, Short Name, Concept, Service Type, Service Status
+a1b2c3d4-0002-0001-0001-000000000001,, Consultation, CONS, 160542AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, Consultation Services, Enabled
+a1b2c3d4-0002-0001-0001-000000000002,, Acetaminophen, ACE, 70116AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, Drug Services, Enabled
+a1b2c3d4-0002-0001-0001-000000000003,, Amoxicillin, AMOX, 723AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, Drug Services, Enabled

--- a/configuration/backend_configuration/cashpoints/cashPoints.csv
+++ b/configuration/backend_configuration/cashpoints/cashPoints.csv
@@ -1,0 +1,2 @@
+Uuid, Void/Retire, Name, Description, Location
+a1b2c3d4-0003-0001-0001-000000000001,, OPD Cash Point, Outpatient cash point, Outpatient Clinic

--- a/configuration/backend_configuration/paymentmodes/paymentModes.csv
+++ b/configuration/backend_configuration/paymentmodes/paymentModes.csv
@@ -1,0 +1,3 @@
+Uuid, Void/Retire, Name, Description, Sort Order
+a1b2c3d4-0004-0001-0001-000000000001,, Cash, Cash payment, 1
+a1b2c3d4-0004-0001-0001-000000000002,, Bank Transfer, Bank transfer payment, 2


### PR DESCRIPTION
## Overview
Fix Version: RefApp 3.7.0
Adds the foundational billing Iniz configuration to the core reference application, enabling the billing module to function out of the box.

## Changes
Created 3 new configuration folders:

**billableservices/billableServices.csv**
- OPD Consultation
- Acetaminophen (drug)
- Amoxicillin (drug)

**cashpoints/cashPoints.csv**
- OPD Cash Point

**paymentmodes/paymentModes.csv**
- Cash
- Bank Transfer

## Why
Previously, billing required manual UI setup after deployment. These Iniz files allow the billing module to be fully configured declaratively, consistent with the OpenMRS initializer-first configuration approach.

## Dependency
Requires the backend fix from openmrs-module-billing#[114]

## Related PRs (merge in order)
1. openmrs/openmrs-module-billing#114 (backend - merge first)
2. openmrs/openmrs-content-referenceapplication#12 (core config)
3. openmrs/openmrs-content-referenceapplication-demo#61 (demo config)